### PR TITLE
Added boilerplate Infrastructure layer

### DIFF
--- a/Lyra.sln
+++ b/Lyra.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "src\Application\Application.csproj", "{E6D98D79-18A0-48D2-BAC7-51E6E379CF20}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure", "src\Infrastructure\Infrastructure.csproj", "{5CDF2FE1-3D7A-4CB0-8B49-06F926B519AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{E6D98D79-18A0-48D2-BAC7-51E6E379CF20}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6D98D79-18A0-48D2-BAC7-51E6E379CF20}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6D98D79-18A0-48D2-BAC7-51E6E379CF20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CDF2FE1-3D7A-4CB0-8B49-06F926B519AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CDF2FE1-3D7A-4CB0-8B49-06F926B519AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CDF2FE1-3D7A-4CB0-8B49-06F926B519AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CDF2FE1-3D7A-4CB0-8B49-06F926B519AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Application/Common/Behaviours/AuthorizationBehaviour.cs
+++ b/src/Application/Common/Behaviours/AuthorizationBehaviour.cs
@@ -47,12 +47,8 @@ namespace Lyra.Application.Common.Behaviours
                         var authorized = false;
                         foreach (var role in roles)
                         {
-                            if (!_currentUserService.UserId.HasValue)
-                                break;
-
                             var isInRole =
-                                await _identityService.IsInRoleAsync(_currentUserService.UserId.Value, role.Trim());
-
+                                await _identityService.IsInRoleAsync(_currentUserService.UserId, role.Trim());
                             if (isInRole)
                             {
                                 authorized = true;
@@ -75,13 +71,7 @@ namespace Lyra.Application.Common.Behaviours
                 {
                     foreach (var policy in authorizeAttributesWithPolicies.Select(a => a.Policy))
                     {
-                        if (!_currentUserService.UserId.HasValue)
-                        {
-                            throw new ForbiddenAccessException();
-                        }
-
-                        var authorized =
-                            await _identityService.AuthorizeAsync(_currentUserService.UserId.Value, policy);
+                        var authorized = await _identityService.AuthorizeAsync(_currentUserService.UserId, policy);
 
                         if (!authorized)
                         {

--- a/src/Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/src/Application/Common/Behaviours/LoggingBehaviour.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Lyra.Application.Common.Interfaces;
+﻿using Lyra.Application.Common.Interfaces;
 using MediatR.Pipeline;
 using Microsoft.Extensions.Logging;
 using System.Threading;
@@ -24,10 +23,10 @@ namespace Lyra.Application.Common.Behaviours
         public async Task Process(TRequest request, CancellationToken cancellationToken)
         {
             var requestName = typeof(TRequest).Name;
-            var userId = _currentUserService.UserId ?? Guid.Empty;
-            var userName = string.Empty;
+            var userId = _currentUserService.UserId ?? string.Empty;
+            string userName = string.Empty;
 
-            if (!userId.Equals(Guid.Empty))
+            if (!string.IsNullOrEmpty(userId))
             {
                 userName = await _identityService.GetUserNameAsync(userId);
             }

--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using MediatR;
+﻿using MediatR;
 using Microsoft.Extensions.Logging;
 using Lyra.Application.Common.Interfaces;
 using System.Diagnostics;
@@ -41,10 +40,10 @@ namespace Lyra.Application.Common.Behaviours
             if (elapsedMilliseconds > 500)
             {
                 var requestName = typeof(TRequest).Name;
-                var userId = _currentUserService.UserId ?? Guid.Empty;
+                var userId = _currentUserService.UserId ?? string.Empty;
                 var userName = string.Empty;
 
-                if (!userId.Equals(Guid.Empty))
+                if (!string.IsNullOrEmpty(userId))
                 {
                     userName = await _identityService.GetUserNameAsync(userId);
                 }

--- a/src/Application/Common/Interfaces/ICurrentUserService.cs
+++ b/src/Application/Common/Interfaces/ICurrentUserService.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Lyra.Application.Common.Interfaces
+﻿namespace Lyra.Application.Common.Interfaces
 {
     public interface ICurrentUserService
     {
-        Guid? UserId { get; }
+        string UserId { get; }
     }
 }

--- a/src/Application/Common/Interfaces/IIdentityService.cs
+++ b/src/Application/Common/Interfaces/IIdentityService.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using Lyra.Application.Common.Models;
+﻿using Lyra.Application.Common.Models;
 using System.Threading.Tasks;
 
 namespace Lyra.Application.Common.Interfaces
 {
     public interface IIdentityService
     {
-        Task<string> GetUserNameAsync(Guid userId);
+        Task<string> GetUserNameAsync(string userId);
 
-        Task<bool> IsInRoleAsync(Guid userId, string role);
+        Task<bool> IsInRoleAsync(string userId, string role);
 
-        Task<bool> AuthorizeAsync(Guid userId, string policyName);
+        Task<bool> AuthorizeAsync(string userId, string policyName);
 
-        Task<(Result Result, Guid userId)> CreateUserAsync(string userName, string password);
+        Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password);
 
-        Task<Result> DeleteUserAsync(Guid userId);
+        Task<Result> DeleteUserAsync(string userId);
     }
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,0 +1,52 @@
+﻿using Lyra.Application.Common.Interfaces;
+using Lyra.Infrastructure.Identity;
+using Lyra.Infrastructure.Persistence;
+using Lyra.Infrastructure.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lyra.Infrastructure
+{
+    public static class DependencyInjection
+    {
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            if (configuration.GetValue<bool>("UseInMemoryDatabase"))
+            {
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase("LyraDb"));
+            }
+            else
+            {
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseSqlServer(
+                        configuration.GetConnectionString("DefaultConnection"),
+                        b => b.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName)));
+            }
+
+            services.AddScoped<IApplicationDbContext>(provider => provider.GetService<ApplicationDbContext>());
+
+            services.AddScoped<IDomainEventService, DomainEventService>();
+
+            services
+                .AddDefaultIdentity<ApplicationUser>()
+                .AddRoles<IdentityRole>()
+                .AddEntityFrameworkStores<ApplicationDbContext>();
+
+            services.AddIdentityServer()
+                .AddApiAuthorization<ApplicationUser, ApplicationDbContext>();
+
+            services.AddTransient<IDateTime, DateTimeService>();
+            services.AddTransient<IIdentityService, IdentityService>();
+
+            services.AddAuthentication()
+                .AddIdentityServerJwt();
+
+            return services;
+        }
+    }
+}

--- a/src/Infrastructure/Identity/ApplicationUser.cs
+++ b/src/Infrastructure/Identity/ApplicationUser.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace Lyra.Infrastructure.Identity
+{
+    public class ApplicationUser : IdentityUser
+    {
+    }
+}

--- a/src/Infrastructure/Identity/IdentityResultExtensions.cs
+++ b/src/Infrastructure/Identity/IdentityResultExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Lyra.Application.Common.Models;
+using Microsoft.AspNetCore.Identity;
+using System.Linq;
+
+namespace Lyra.Infrastructure.Identity
+{
+    public static class IdentityResultExtensions
+    {
+        public static Result ToApplicationResult(this IdentityResult result)
+        {
+            return result.Succeeded
+                ? Result.Success()
+                : Result.Failure(result.Errors.Select(e => e.Description));
+        }
+    }
+}

--- a/src/Infrastructure/Identity/IdentityService.cs
+++ b/src/Infrastructure/Identity/IdentityService.cs
@@ -1,0 +1,84 @@
+﻿using Lyra.Application.Common.Interfaces;
+using Lyra.Application.Common.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Lyra.Infrastructure.Identity
+{
+    public class IdentityService : IIdentityService
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IUserClaimsPrincipalFactory<ApplicationUser> _userClaimsPrincipalFactory;
+        private readonly IAuthorizationService _authorizationService;
+
+        public IdentityService(
+            UserManager<ApplicationUser> userManager,
+            IUserClaimsPrincipalFactory<ApplicationUser> userClaimsPrincipalFactory,
+            IAuthorizationService authorizationService)
+        {
+            _userManager = userManager;
+            _userClaimsPrincipalFactory = userClaimsPrincipalFactory;
+            _authorizationService = authorizationService;
+        }
+
+        public async Task<string> GetUserNameAsync(string userId)
+        {
+            var user = await _userManager.Users.FirstAsync(u => u.Id == userId);
+
+            return user.UserName;
+        }
+
+        public async Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password)
+        {
+            var user = new ApplicationUser
+            {
+                UserName = userName,
+                Email = userName,
+            };
+
+            var result = await _userManager.CreateAsync(user, password);
+
+            return (result.ToApplicationResult(), user.Id);
+        }
+
+        public async Task<bool> IsInRoleAsync(string userId, string role)
+        {
+            var user = _userManager.Users.SingleOrDefault(u => u.Id == userId);
+
+            return await _userManager.IsInRoleAsync(user, role);
+        }
+
+        public async Task<bool> AuthorizeAsync(string userId, string policyName)
+        {
+            var user = _userManager.Users.SingleOrDefault(u => u.Id == userId);
+
+            var principal = await _userClaimsPrincipalFactory.CreateAsync(user);
+
+            var result = await _authorizationService.AuthorizeAsync(principal, policyName);
+
+            return result.Succeeded;
+        }
+
+        public async Task<Result> DeleteUserAsync(string userId)
+        {
+            var user = _userManager.Users.SingleOrDefault(u => u.Id == userId);
+
+            if (user != null)
+            {
+                return await DeleteUserAsync(user);
+            }
+
+            return Result.Success();
+        }
+
+        public async Task<Result> DeleteUserAsync(ApplicationUser user)
+        {
+            var result = await _userManager.DeleteAsync(user);
+
+            return result.ToApplicationResult();
+        }
+    }
+}

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <RootNamespace>Lyra.Infrastructure</RootNamespace>
+        <AssemblyName>Lyra.Infrastructure</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="5.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Application\Application.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Persistence\Configurations" />
+      <Folder Include="Persistence\Migrations" />
+    </ItemGroup>
+    
+</Project>

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,0 +1,84 @@
+﻿using Lyra.Application.Common.Interfaces;
+using Lyra.Domain.Common;
+using Lyra.Infrastructure.Identity;
+using IdentityServer4.EntityFramework.Options;
+using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lyra.Infrastructure.Persistence
+{
+    public class ApplicationDbContext : ApiAuthorizationDbContext<ApplicationUser>, IApplicationDbContext
+    {
+        private readonly ICurrentUserService _currentUserService;
+        private readonly IDateTime _dateTime;
+        private readonly IDomainEventService _domainEventService;
+
+        public ApplicationDbContext(
+            DbContextOptions options,
+            IOptions<OperationalStoreOptions> operationalStoreOptions,
+            ICurrentUserService currentUserService,
+            IDomainEventService domainEventService,
+            IDateTime dateTime) : base(options, operationalStoreOptions)
+        {
+            _currentUserService = currentUserService;
+            _domainEventService = domainEventService;
+            _dateTime = dateTime;
+        }
+
+        //TODO: Add DbSets
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<AuditableEntity> entry in ChangeTracker
+                .Entries<AuditableEntity>())
+            {
+                switch (entry.State)
+                {
+                    case EntityState.Added:
+                        entry.Entity.CreatedBy = _currentUserService.UserId;
+                        entry.Entity.Created = _dateTime.Now;
+                        break;
+
+                    case EntityState.Modified:
+                        entry.Entity.LastModifiedBy = _currentUserService.UserId;
+                        entry.Entity.LastModified = _dateTime.Now;
+                        break;
+                }
+            }
+
+            var result = await base.SaveChangesAsync(cancellationToken);
+
+            await DispatchEvents();
+
+            return result;
+        }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+
+            base.OnModelCreating(builder);
+        }
+
+        private async Task DispatchEvents()
+        {
+            while (true)
+            {
+                var domainEventEntity = ChangeTracker
+                    .Entries<IHasDomainEvent>()
+                    .Select(x => x.Entity.DomainEvents)
+                    .SelectMany(x => x)
+                    .FirstOrDefault(domainEvent => !domainEvent.IsPublished);
+                if (domainEventEntity == null) break;
+
+                domainEventEntity.IsPublished = true;
+                await _domainEventService.Publish(domainEventEntity);
+            }
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/ApplicationDbContextSeed.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContextSeed.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Lyra.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Lyra.Infrastructure.Persistence
+{
+    public static class ApplicationDbContextSeed
+    {
+        public static async Task SeedDefaultUserAsync(UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager)
+        {
+            var administratorRole = new IdentityRole("Administrator");
+
+            if (roleManager.Roles.All(r => r.Name != administratorRole.Name))
+            {
+                await roleManager.CreateAsync(administratorRole);
+            }
+
+            var administrator = new ApplicationUser
+                {UserName = "administrator@localhost", Email = "administrator@localhost"};
+
+            if (userManager.Users.All(u => u.UserName != administrator.UserName))
+            {
+                await userManager.CreateAsync(administrator, "Administrator1!");
+                await userManager.AddToRolesAsync(administrator, new[] {administratorRole.Name});
+            }
+        }
+
+        public static async Task SeedSampleDataAsync(ApplicationDbContext context)
+        {
+            //TODO: Add seed logic
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Infrastructure/Services/DateTimeService.cs
+++ b/src/Infrastructure/Services/DateTimeService.cs
@@ -1,0 +1,10 @@
+﻿using Lyra.Application.Common.Interfaces;
+using System;
+
+namespace Lyra.Infrastructure.Services
+{
+    public class DateTimeService : IDateTime
+    {
+        public DateTime Now => DateTime.Now;
+    }
+}

--- a/src/Infrastructure/Services/DomainEventService.cs
+++ b/src/Infrastructure/Services/DomainEventService.cs
@@ -1,0 +1,34 @@
+﻿using Lyra.Application.Common.Interfaces;
+using Lyra.Application.Common.Models;
+using Lyra.Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Lyra.Infrastructure.Services
+{
+    public class DomainEventService : IDomainEventService
+    {
+        private readonly ILogger<DomainEventService> _logger;
+        private readonly IPublisher _mediator;
+
+        public DomainEventService(ILogger<DomainEventService> logger, IPublisher mediator)
+        {
+            _logger = logger;
+            _mediator = mediator;
+        }
+
+        public async Task Publish(DomainEvent domainEvent)
+        {
+            _logger.LogInformation("Publishing domain event. Event - {event}", domainEvent.GetType().Name);
+            await _mediator.Publish(GetNotificationCorrespondingToDomainEvent(domainEvent));
+        }
+
+        private INotification GetNotificationCorrespondingToDomainEvent(DomainEvent domainEvent)
+        {
+            return (INotification) Activator.CreateInstance(
+                typeof(DomainEventNotification<>).MakeGenericType(domainEvent.GetType()), domainEvent);
+        }
+    }
+}


### PR DESCRIPTION
﻿### What does it fix?

Closes #5
Added infrastructure layer, which contains persistence and identity related services.

Also moved Identity interfaces from Application layer from Guid user Ids to string user Ids as it was too annoying to adapt EF-Core to Guids.